### PR TITLE
Add checkbox to keep option updates during dcs session

### DIFF
--- a/DCS-Shortcut-Generator/MainWindow.xaml
+++ b/DCS-Shortcut-Generator/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
         xmlns:local="clr-namespace:DCS_Shortcut_Generator"
         mc:Ignorable="d"
-        Title="DCS Shortcut Generator v1.2 by Bailey" Height="390" Width="500">
+        Title="DCS Shortcut Generator v1.2 by Bailey" Height="450" Width="500">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="5"/>
@@ -18,6 +18,7 @@
 
         <Grid.RowDefinitions>
             <RowDefinition Height="5"/>
+            <RowDefinition Height="AUTO"/>
             <RowDefinition Height="AUTO"/>
             <RowDefinition Height="AUTO"/>
             <RowDefinition Height="AUTO"/>
@@ -71,19 +72,18 @@
         
         <TextBox x:Name="textBlock_userOptionsNewFile" Grid.Row="9" Grid.Column="2" Grid.ColumnSpan="2" Margin="5" Height="20" 
                  VerticalAlignment="Center" IsEnabled="False"/>
+        <CheckBox x:Name="checkBox_updateOptions" Grid.Row="10" Grid.Column="2" Grid.ColumnSpan="2" Margin="5"  IsEnabled="False">Keep options changes done during DCS session</CheckBox>
         <Button x:Name="button_userOptionsNewFile" Content="Select Swap Options.lua" Grid.Row="9" Grid.Column="1" Margin="5" 
                 Height="20" VerticalAlignment="Center" Click="button_userOptionsNewFile_Click"/>
-
         
-        
-        <Label Content="DCS Width Override" Grid.Row="10" Grid.Column="1"  Margin="0" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-        <TextBox x:Name="textBlock_dcsWidth" Grid.Row="10" Grid.Column="2" Grid.ColumnSpan="1" Margin="5" Width="75" Height="20" 
+        <Label Content="DCS Width Override" Grid.Row="11" Grid.Column="1"  Margin="0" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+        <TextBox x:Name="textBlock_dcsWidth" Grid.Row="11" Grid.Column="2" Grid.ColumnSpan="1" Margin="5" Width="75" Height="20" 
                  VerticalAlignment="Center" HorizontalAlignment="Left" PreviewTextInput="NumberValidationTextBox" PreviewKeyDown="textBlock_dcsWidth_PreviewKeyDown"
                  CommandManager.PreviewExecuted="textBox_PreviewExecuted" ContextMenu="{x:Null}"/>
 
 
-        <Label Content="DCS Height Override" Grid.Row="11" Grid.Column="1" Margin="0" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-        <TextBox x:Name="textBlock_dcsHeight" Grid.Row="11" Grid.Column="2" Grid.ColumnSpan="1" Margin="5" Width="75" Height="20" 
+        <Label Content="DCS Height Override" Grid.Row="12" Grid.Column="1" Margin="0" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+        <TextBox x:Name="textBlock_dcsHeight" Grid.Row="12" Grid.Column="2" Grid.ColumnSpan="1" Margin="5" Width="75" Height="20" 
                  VerticalAlignment="Center" HorizontalAlignment="Left" PreviewTextInput="NumberValidationTextBox" 
                  PreviewKeyDown="textBlock_dcsHeight_PreviewKeyDown" CommandManager.PreviewExecuted="textBox_PreviewExecuted" ContextMenu="{x:Null}"/>
 


### PR DESCRIPTION
This change adds the option to keep the changes done while you are playing DCS for a particular shortcut.

Note: If the checkbox its unchecked during shortcut creation, this application will works as usual
Note 2: This change is not backward compatible with previously created shortcuts, so in order to use this version, the shortcuts must be created again using this executable

Example:
You have one Shortcut for VR and one for Flat (each with its own custom options.lua).

You execute the Flat version and make a change in the options (normally, this change will be lost in the next execution since we will take the same Flat options.lua file again), if you have the new checkbox checked, the change you made will be saved as the Flat options.lua file, so the next time you execute the Flat shortcut, it will have the change

The change will not affect the VR options.lua unless you execute from the VR shortcut instead and then make the options change
